### PR TITLE
Using event name for pagerduty incident key

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "statsd-alerting-backend",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A simple StatsD backend to send customizable alerts",
   "keywords": [
     "statsd",

--- a/src/alerts/index.coffee
+++ b/src/alerts/index.coffee
@@ -3,4 +3,3 @@ module.exports =
   pagerduty: require './pagerduty'
   sentry: require './sentry'
   slack: require './slack'
-

--- a/src/alerts/pagerduty.coffee
+++ b/src/alerts/pagerduty.coffee
@@ -6,7 +6,8 @@ module.exports = class PagerdutyAlert extends Alert
     @pager = new Pagerduty serviceKey: @config.key
 
   sendToPagerduty: (description, event) ->
-    @pager.create {description, details: event}
+    {name} = event
+    @pager.create {description, incidentKey: name, details: event}
 
   sendEvent: (event) ->
     @sendToPagerduty 'event alert', event


### PR DESCRIPTION
This will cluster together Pagerduty alerts for the same incident.