### PR TITLE
Created a dispatcher for HipChat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 node_modules
 lib

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
-.idea
 node_modules
 lib

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "node_modules/.bin/mocha -r coffee-script/register test/**/*_test.coffee"
   },
   "dependencies": {
+    "hipchatter": "^0.2.0",
     "pagerduty": "0.0.3",
     "raven": "^0.6.3",
     "request": "^2.48.0",

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ to Javascript files.
 Here you can define a set of dispatchers to use when sending alerts. They can
 be named anything (names must be unique as it is a Javascript object). See the
 example config file for formatting. Each dispatcher must have a type that is
-one of the valid alert dispatchers (currently "slack", "pagerduty", and "log").
+one of the valid alert dispatchers (currently "slack", "pagerduty", "hipchat", and "log").
 Each dispatcher must also include the necessary configuration for the alert
 dispatcher.
 
@@ -81,6 +81,16 @@ Simply list your Pagerduty service key.
 #### `sentry` configuration
 
 Simply list your Sentry DSN.
+
+#### `hipchat` configuration
+
+List your hipchat api `key` and the `room` name to which you want to send the alerts.
+If a room with that name does not exist, then the backend will create it for you.
+Optionally you can also set a `color` for the messages sent to hipchat. Available colors are
+yellow (default), red, green, purple, gray and random.
+
+Make sure that the key provided has enabled the scopes `manage_rooms` (necessary for the backend
+to create the room in case it doesn't exist), `view_room` and `send_notification`.
 
 #### `log` configuration
 
@@ -141,6 +151,15 @@ values for whichever alerting sources you specify in your configuration file.
         type: "sentry",
         config: {
           dsn: "<SENTRY_DSN>"
+        }
+      },
+      
+      hipchatDispatcher: {
+        type: "hipchat",
+        config: {
+          key: "<HIPCHAT_API_KEY>",
+          room: "<HIPCHAT_ROOM_NAME>",
+          color: "red"
         }
       },
 

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,8 @@ to Javascript files.
 Here you can define a set of dispatchers to use when sending alerts. They can
 be named anything (names must be unique as it is a Javascript object). See the
 example config file for formatting. Each dispatcher must have a type that is
-one of the valid alert dispatchers (currently "slack", "pagerduty", "hipchat", and "log").
+one of the valid alert dispatchers (currently "slack", "pagerduty", "hipchat", 
+and "log").
 Each dispatcher must also include the necessary configuration for the alert
 dispatcher.
 
@@ -84,13 +85,15 @@ Simply list your Sentry DSN.
 
 #### `hipchat` configuration
 
-List your hipchat api `key` and the `room` name to which you want to send the alerts.
-If a room with that name does not exist, then the backend will create it for you.
-Optionally you can also set a `color` for the messages sent to hipchat. Available colors are
-yellow (default), red, green, purple, gray and random.
+List your hipchat api `key` and the `room` name to which you want to send the 
+alerts. If a room with that name does not exist, then the backend will create 
+it for you. Optionally you can also set a `color` for the messages sent to 
+hipchat. Available colors are yellow (default), red, green, purple, 
+gray and random.
 
-Make sure that the key provided has enabled the scopes `manage_rooms` (necessary for the backend
-to create the room in case it doesn't exist), `view_room` and `send_notification`.
+Make sure that the key provided has enabled the scopes `manage_rooms` 
+(necessary for the backend to create the room in case it doesn't exist), 
+`view_room` and `send_notification`.
 
 #### `log` configuration
 

--- a/src/alerts/hipchat.coffee
+++ b/src/alerts/hipchat.coffee
@@ -17,7 +17,7 @@ module.exports = class HipChatAlert extends Alert
   sendToHipChat: (message) ->
     options =
       message: message
-      color: if @config.color then @config.color else 'yellow'
+      color: @config.color or 'yellow'
     @api.notify @config.room, options, (err, response) ->
       if err
         throw new Error "[Hipchat] Couldn't send message to room: #{err}"

--- a/src/alerts/hipchat.coffee
+++ b/src/alerts/hipchat.coffee
@@ -1,5 +1,4 @@
 Alert = require './alert'
-request = require 'request'
 Hipchatter = require 'hipchatter'
 
 module.exports = class HipChatAlert extends Alert
@@ -18,7 +17,7 @@ module.exports = class HipChatAlert extends Alert
   sendToHipChat: (message) ->
     options =
       message: message
-      color: @config.color ? 'yellow'
+      color: if @config.color then @config.color else 'yellow'
     @api.notify @config.room, options, (err, response) ->
       if err
         throw new Error "[Hipchat] Couldn't send message to room: #{err}"

--- a/src/alerts/hipchat.coffee
+++ b/src/alerts/hipchat.coffee
@@ -15,6 +15,7 @@ module.exports = class HipChatAlert extends Alert
             throw new Error "[Hipchat] Couldn't create room: #{err}"
 
   sendToHipChat: (message) ->
+    # color of the message defaults to yellow if it's falsey in the config
     options =
       message: message
       color: @config.color or 'yellow'

--- a/src/alerts/hipchat.coffee
+++ b/src/alerts/hipchat.coffee
@@ -1,0 +1,36 @@
+Alert = require './alert'
+request = require 'request'
+Hipchatter = require 'hipchatter'
+
+module.exports = class HipChatAlert extends Alert
+  constructor: (@config) ->
+    @api = new Hipchatter @config.key
+    # Check that the configured room exists, otherwise create it
+    @api.get_room @config.room, (err, response) ->
+      if err
+        # room does not exist, let's create it
+        room_data =
+          name: @config.room
+        @api.create_room room_data, (err, response) ->
+          if err
+            throw new Error "[Hipchat] Couldn't create room: #{err}"
+
+  sendToHipChat: (message) ->
+    options =
+      message: message
+      color: @config.color ? 'yellow'
+    @api.notify @config.room, options, (err, response) ->
+      if err
+        throw new Error "[Hipchat] Couldn't send message to room: #{err}"
+
+  sendEvent: (event) ->
+    @sendToHipChat [
+      "Event alert for #{event.name}!"
+      "```#{JSON.stringify event}```"
+    ].join '\n'
+
+  sendMetricsEvent: (event) ->
+    @sendToHipChat [
+      "Metrics alert for #{event.name}!"
+      "```#{JSON.stringify event}```"
+    ].join '\n'

--- a/src/alerts/index.coffee
+++ b/src/alerts/index.coffee
@@ -3,3 +3,4 @@ module.exports =
   pagerduty: require './pagerduty'
   sentry: require './sentry'
   slack: require './slack'
+  hipchat: require './hipchat'

--- a/test/alert_distributor_test.coffee
+++ b/test/alert_distributor_test.coffee
@@ -18,6 +18,9 @@ describe 'AlertDistributor', ->
         slack:
           type: 'slack'
           config: {}
+        hipchat:
+          type: 'hipchat'
+          config: {}
 
   describe 'parsePacket', ->
     beforeEach ->

--- a/test/integration_test.coffee
+++ b/test/integration_test.coffee
@@ -21,6 +21,9 @@ describe 'Integration Test', ->
           sentry:
             type: 'sentry'
             config: dsn: ''
+          hipchat:
+            type: 'hipchat'
+            config: {}
         events: eventConfig.events
         metrics: eventConfig.metrics
 
@@ -66,15 +69,19 @@ describe 'Integration Test', ->
         ,
           name: 'test.sentry.event'
           dispatcher: 'sentry'
+        ,
+          name: 'test.hipchat.event'
+          dispatcher: 'hipchat'
         ]
 
-      @dispatchesEvents 'slack', 'pagerduty', 'log', 'sentry'
+      @dispatchesEvents 'slack', 'pagerduty', 'log', 'sentry', 'hipchat'
 
       @packet [
         'test.slack.event:1|c'
         'test.pagerduty.event:1|c'
         'test.log.event:1|c'
         'test.sentry.event:1|c'
+        'test.hipchat.event:1|c'
       ].join '\n'
 
       @verifyMocks()
@@ -95,16 +102,21 @@ describe 'Integration Test', ->
           name: 'test.sentry.event'
           gte: 5
           dispatcher: 'sentry'
+        ,
+          name: 'test.hipchat.event'
+          gte: 2
+          dispatcher: 'hipchat'
         ]
 
       @dispatchesEvents 'slack', 'pagerduty'
-      @noEventsDispatchedFor 'log', 'sentry'
+      @noEventsDispatchedFor 'log', 'sentry', 'hipchat'
 
       @packet [
         'test.slack.event:1|c'
         'test.pagerduty.event:1|c'
         'test.log.event:1|c'
         'test.sentry.event:1|c'
+        'test.hipchat.event:1|c'
       ].join '\n'
 
       @verifyMocks()
@@ -156,6 +168,11 @@ describe 'Integration Test', ->
           key: 'mean_90'
           delta_lt: 10
           dispatcher: 'log'
+        ,
+          name: 'test.hipchat.metric'
+          type: 'counter_rates'
+          gte: 0.2
+          dispatcher: 'hipchat'
         ]
 
       # This is gross. Sorry.
@@ -169,6 +186,7 @@ describe 'Integration Test', ->
       @flush
         counter_rates:
           'test.slack.metric': 0.4
+          'test.hipchat.metric': 0.6
         timer_data:
           'test.pagerduty.metric':
             mean_90: 9


### PR DESCRIPTION
I've created a new dispatcher which sends alerts to a configured hipchat room. It uses the hipchatter node library to call the API endpoints.
In case the configured room does not exist in the given hipchat account, it will create it.
I've also added this new dispatcher to some of the tests you already had and updated the configuration with the new dispatcher.